### PR TITLE
added secondary order clause to my_nets.php

### DIFF
--- a/web/content/my_nets.php
+++ b/web/content/my_nets.php
@@ -16,7 +16,7 @@ if ($k != '') {
     $stmt->prepare('SELECT SQL_CALC_FOUND_ROWS hex(nets.hash) as hash, nets.bssid AS bssid, nets.ssid AS ssid, nets.keyver AS keyver, nets.pass AS pass, nets.n_state AS n_state, nets.hits, n2u.ts
 FROM nets, n2u, users
 WHERE nets.net_id=n2u.net_id AND users.u_id=n2u.u_id AND users.userkey=UNHEX(?)
-ORDER BY nets.ts DESC
+ORDER BY nets.ts DESC, nets.bssid ASC
 LIMIT ?,?');
     $stmt->bind_param('sii', $k, $offset, $limit);
     $stmt->execute();


### PR DESCRIPTION
added secondary order clause to my_nets.php to prevent quantum fluctuations in MySQL when more than one rows share the same timestamp