### PR TITLE
Remove comma

### DIFF
--- a/db/wpa.sql
+++ b/db/wpa.sql
@@ -228,7 +228,7 @@ CREATE TABLE IF NOT EXISTS `submissions` (
   `ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Submission timestamp',
   PRIMARY KEY (`s_id`),
   UNIQUE KEY `UNC_submissions_localfile` (`localfile`) USING BTREE,
-  UNIQUE KEY `UNC_submissions_hash` (`hash`) USING BTREE,
+  UNIQUE KEY `UNC_submissions_hash` (`hash`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Capture file submissions';
 
 --


### PR DESCRIPTION
Remove comma causing SQL syntax error.

MySQL 5.7 Ubuntu 18.04
```
$ mysql -u wpa -p wpa < wpa.sql

ERROR 1064 (42000) at line 223: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Capture file submissions'' at line 10
```